### PR TITLE
Suggestions to improve the test case XSD

### DIFF
--- a/TestCases/testCases.xsd
+++ b/TestCases/testCases.xsd
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by Bruce Silver (private) -->
 <xs:schema xmlns="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.omg.org/spec/DMN/20160719/testcase" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:element name="TestCases">
+	<xs:element name="testCases">
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="modelName" type="xs:string" minOccurs="0"/>
+				<xs:element name="labels" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="label" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
 				<xs:element name="testCase" maxOccurs="unbounded">
 					<xs:complexType>
 						<xs:sequence>
+							<xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string" />
 							<xs:element name="inputNode" maxOccurs="unbounded">
 								<xs:complexType>
 									<xs:complexContent>


### PR DESCRIPTION
- renaming "TestCases" to "testCases" to conform with the camel case standard on other elements
- adding "labels" element to annotate test cases. The labels can then be used by query and reporting tools later to group and filter test cases.
- adding "description" element into the "testCase" element to allow for test case documentation for automated reporting.
