### PR TITLE
Fixing test cases where attr ID cannot start with a digit ..

### DIFF
--- a/TestCases/compliance-level-2/0001-input-data-string/0001-input-data-string.dmn
+++ b/TestCases/compliance-level-2/0001-input-data-string/0001-input-data-string.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="0001-input-data-string" name="0001-input-data-string"
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
 	namespace="https://github.com/agilepro/dmn-tck"
 	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
 	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">

--- a/TestCases/compliance-level-2/0002-input-data-number/0002-input-data-number.dmn
+++ b/TestCases/compliance-level-2/0002-input-data-number/0002-input-data-number.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="0002-input-data-number" name="0002-input-data-number"
+<definitions id="_0002-input-data-number" name="0002-input-data-number"
 	namespace="https://github.com/agilepro/dmn-tck"
 	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
 	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">

--- a/TestCases/compliance-level-2/0003-input-data-string-allowed-values/0003-input-data-string-allowed-values.dmn
+++ b/TestCases/compliance-level-2/0003-input-data-string-allowed-values/0003-input-data-string-allowed-values.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="0003-input-data-string-allowed-values" name="0003-input-data-string-allowed-values"
+<definitions id="_0003-input-data-string-allowed-values" name="0003-input-data-string-allowed-values"
 	namespace="https://github.com/agilepro/dmn-tck"
 	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
 	xmlns:feel="http://www.omg.org/spec/FEEL/20140401"


### PR DESCRIPTION
.. being xsd:ID, being xsd:NCName, being xsd:Name cannot start with
digit.

Ref. NCName Pattern: [\i-[:]][\c-[:]]*