### PR TITLE
Fix 0006-join.dmn "tEmployeeTable" itemDefinition

### DIFF
--- a/TestCases/compliance-level-3/0006-join/0006-join.dmn
+++ b/TestCases/compliance-level-3/0006-join/0006-join.dmn
@@ -10,9 +10,6 @@
 		<itemComponent id="_fa7afb54-265e-4244-97bf-4789c48e3629" name="deptNum">
 			<typeRef>feel:number</typeRef>
 		</itemComponent>
-		<itemComponent id="_df562869-8cda-4a15-a37d-e121a4f7abac" name="mgrName">
-			<typeRef>feel:string</typeRef>
-		</itemComponent>
 	</itemDefinition>
 	<itemDefinition id="tDeptTable" name="tDeptTable" isCollection="true">
 		<itemComponent id="_f7e37827-f9ab-4fb1-b07e-9e4367242e65" name="number">


### PR DESCRIPTION
Based on the input data for the test in subject,
https://github.com/agilepro/dmn-tck/blob/master/TestCases/compliance-level-3/0006-join/0006-join-test-01.xml#L16-L70
an instance of tEmployeeTable is actually composed of: `id`, `deptNum`, `name` only.

@etirelli can you please review?