### PR TITLE
Fix 0008-listGen expressions be compatible with decl. type tStringList

### DIFF
--- a/TestCases/compliance-level-3/0008-listGen/0008-listGen-test-01.xml
+++ b/TestCases/compliance-level-3/0008-listGen/0008-listGen-test-01.xml
@@ -108,14 +108,10 @@
 			<expected>
 				<list>
 					<item>
-						<list>
-							<item>
-								<value>w</value>
-							</item>
-							<item>
-								<value>x</value>
-							</item>
-						</list>
+						<value>w</value>
+					</item>
+					<item>
+						<value>x</value>
 					</item>
 					<item>
 						<value>y</value>
@@ -130,14 +126,10 @@
 			<expected>
 				<list>
 					<item>
-						<list>
-							<item>
-								<value>w</value>
-							</item>
-							<item>
-								<value>x</value>
-							</item>
-						</list>
+						<value>w</value>
+					</item>
+					<item>
+						<value>x</value>
 					</item>
 					<item>
 						<value>y</value>
@@ -158,24 +150,16 @@
 						<value>b</value>
 					</item>
 					<item>
-						<list>
-							<item>
-								<list>
-									<item>
-										<value>w</value>
-									</item>
-									<item>
-										<value>x</value>
-									</item>
-								</list>
-							</item>
-							<item>
-								<value>y</value>
-							</item>
-							<item>
-								<value>z</value>
-							</item>
-						</list>
+						<value>w</value>
+					</item>
+					<item>
+						<value>x</value>
+					</item>
+					<item>
+						<value>y</value>
+					</item>
+					<item>
+						<value>z</value>
 					</item>
 				</list>
 			</expected>
@@ -190,24 +174,16 @@
 						<value>b</value>
 					</item>
 					<item>
-						<list>
-							<item>
-								<list>
-									<item>
-										<value>w</value>
-									</item>
-									<item>
-										<value>x</value>
-									</item>
-								</list>
-							</item>
-							<item>
-								<value>y</value>
-							</item>
-							<item>
-								<value>z</value>
-							</item>
-						</list>
+						<value>w</value>
+					</item>
+					<item>
+						<value>x</value>
+					</item>
+					<item>
+						<value>y</value>
+					</item>
+					<item>
+						<value>z</value>
 					</item>
 				</list>
 			</expected>
@@ -216,37 +192,25 @@
 			<expected>
 				<list>
 					<item>
-						<list>
-							<item>
-								<value>a</value>
-							</item>
-							<item>
-								<value>b</value>
-							</item>
-							<item>
-								<value>c</value>
-							</item>
-						</list>
+						<value>a</value>
 					</item>
 					<item>
-						<list>
-							<item>
-								<list>
-									<item>
-										<value>w</value>
-									</item>
-									<item>
-										<value>x</value>
-									</item>
-								</list>
-							</item>
-							<item>
-								<value>y</value>
-							</item>
-							<item>
-								<value>z</value>
-							</item>
-						</list>
+						<value>b</value>
+					</item>
+					<item>
+						<value>c</value>
+					</item>
+					<item>
+						<value>w</value>
+					</item>
+					<item>
+						<value>x</value>
+					</item>
+					<item>
+						<value>y</value>
+					</item>
+					<item>
+						<value>z</value>
 					</item>
 				</list>
 			</expected>

--- a/TestCases/compliance-level-3/0008-listGen/0008-listGen.dmn
+++ b/TestCases/compliance-level-3/0008-listGen/0008-listGen.dmn
@@ -161,7 +161,7 @@
 	<decision id="_50554bc6-d4e1-468b-a620-db2d35da5a0b" name="listGen6">
 		<variable name="listGen6" typeRef="tns:tStringList"/>
 		<literalExpression>
-			<text>[["w","x"],"y","z"]</text>
+			<text>flatten([["w","x"],"y","z"])</text>
 		</literalExpression>
 	</decision>
 	<decision id="_6d3062b2-55d4-4299-aeb2-a5e97e03daec" name="listGen7">
@@ -170,7 +170,7 @@
 			<requiredInput href="#_c51e77a1-30a4-4f23-9054-6c359bf80e9f"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>[wx,"y","z"]</text>
+			<text>flatten([wx,"y","z"])</text>
 		</literalExpression>
 	</decision>
 	<decision id="_bd8b0287-1ff4-4c13-b0ef-68cff151cabd" name="listGen8">
@@ -185,7 +185,7 @@
 			<requiredDecision href="#_50554bc6-d4e1-468b-a620-db2d35da5a0b"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>[a,b,listGen6]</text>
+			<text>flatten([a,b,listGen6])</text>
 		</literalExpression>
 	</decision>
 	<decision id="_64ccac33-c22b-454d-b763-5a77ffd38678" name="listGen9">
@@ -200,7 +200,7 @@
 			<requiredDecision href="#_6d3062b2-55d4-4299-aeb2-a5e97e03daec"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>[a,b,listGen7]</text>
+			<text>flatten([a,b,listGen7])</text>
 		</literalExpression>
 	</decision>
 	<decision id="_9d464a01-5230-4270-88b6-f8e08d03e10b" name="listGen10">
@@ -212,7 +212,7 @@
 			<requiredDecision href="#_ca299168-4590-4040-bb10-beb7d1a6932b"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>[listGen4,listGen7]</text>
+			<text>flatten([listGen4,listGen7])</text>
 		</literalExpression>
 	</decision>
 </definitions>


### PR DESCRIPTION
...and fix the test expected output accordingly.

The 0008-listGen model defines the following type

```
	<itemDefinition id="tStringList" name="tStringList" isCollection="true">
		<typeRef>feel:string</typeRef>
	</itemDefinition>
```

and here: https://github.com/agilepro/dmn-tck/blob/master/TestCases/compliance-level-3/0008-listGen/0008-listGen.dmn#L161-L166
the hardcoded expression

```
[["w","x"],"y","z"]
```

is defined as of type tStringList.

This is wrong.

One potential solution is to introduce a new type, as:

```
    <itemDefinition id="tListOfLists" name="tListOfLists" isCollection="true">
        <typeRef>tns:tStringList</typeRef>
    </itemDefinition>
```

and following Decisions "listGen6" and "listGen7" https://github.com/agilepro/dmn-tck/blob/master/TestCases/compliance-level-3/0008-listGen/0008-listGen.dmn#L161-L175
should become of type tListOfLists.

Then more generally the problem of the remaining decisions
For Decision `listGen8`  result is `[a, b, [[w, x], y, z]]`
For Decision `listGen9`  result is `[a, b, [[w, x], y, z]]` 
For Decision `listGen10` result is `[[a, b, c], [[w, x], y, z]]`

which is not tStringList and not tListOfLists either, because nested
within a 3 level structure.

In order to more generically address the current issue, it is proposed
for this test to simply use homogeneous lists, which is more aligned
with DMN1.1 list usages.