### PR TITLE
Fix 0009-append-flatten expressions compatibility decl. type tNestedList

### DIFF
--- a/TestCases/compliance-level-3/0009-append-flatten/0009-append-flatten-test-01.xml
+++ b/TestCases/compliance-level-3/0009-append-flatten/0009-append-flatten-test-01.xml
@@ -111,31 +111,31 @@
 			<expected>
 				<list>
 					<item>
-						<value>a</value>
+						<list>
+							<item>
+								<value>w</value>
+							</item>
+							<item>
+								<value>x</value>
+							</item>
+						</list>
 					</item>
 					<item>
-						<value>b</value>
+						<value>y</value>
 					</item>
 					<item>
-						<value>c</value>
+						<value>z</value>
 					</item>
 					<item>
 						<list>
 							<item>
-								<list>
-									<item>
-										<value>w</value>
-									</item>
-									<item>
-										<value>x</value>
-									</item>
-								</list>
+								<value>a</value>
 							</item>
 							<item>
-								<value>y</value>
+								<value>b</value>
 							</item>
 							<item>
-								<value>z</value>
+								<value>c</value>
 							</item>
 						</list>
 					</item>
@@ -146,31 +146,31 @@
 			<expected>
 				<list>
 					<item>
-						<value>a</value>
+						<list>
+							<item>
+								<value>w</value>
+							</item>
+							<item>
+								<value>x</value>
+							</item>
+						</list>
 					</item>
 					<item>
-						<value>b</value>
+						<value>y</value>
 					</item>
 					<item>
-						<value>c</value>
+						<value>z</value>
 					</item>
 					<item>
 						<list>
 							<item>
-								<list>
-									<item>
-										<value>w</value>
-									</item>
-									<item>
-										<value>x</value>
-									</item>
-								</list>
+								<value>a</value>
 							</item>
 							<item>
-								<value>y</value>
+								<value>b</value>
 							</item>
 							<item>
-								<value>z</value>
+								<value>c</value>
 							</item>
 						</list>
 					</item>
@@ -181,31 +181,31 @@
 			<expected>
 				<list>
 					<item>
-						<value>a</value>
+						<list>
+							<item>
+								<value>w</value>
+							</item>
+							<item>
+								<value>x</value>
+							</item>
+						</list>
 					</item>
 					<item>
-						<value>b</value>
+						<value>y</value>
 					</item>
 					<item>
-						<value>c</value>
+						<value>z</value>
 					</item>
 					<item>
 						<list>
 							<item>
-								<list>
-									<item>
-										<value>w</value>
-									</item>
-									<item>
-										<value>x</value>
-									</item>
-								</list>
+								<value>a</value>
 							</item>
 							<item>
-								<value>y</value>
+								<value>b</value>
 							</item>
 							<item>
-								<value>z</value>
+								<value>c</value>
 							</item>
 						</list>
 					</item>
@@ -240,15 +240,6 @@
 			<expected>
 				<list>
 					<item>
-						<value>a</value>
-					</item>
-					<item>
-						<value>b</value>
-					</item>
-					<item>
-						<value>c</value>
-					</item>
-					<item>
 						<value>w</value>
 					</item>
 					<item>
@@ -259,6 +250,15 @@
 					</item>
 					<item>
 						<value>z</value>
+					</item>
+					<item>
+						<value>a</value>
+					</item>
+					<item>
+						<value>b</value>
+					</item>
+					<item>
+						<value>c</value>
 					</item>
 				</list>
 			</expected>
@@ -267,15 +267,6 @@
 			<expected>
 				<list>
 					<item>
-						<value>a</value>
-					</item>
-					<item>
-						<value>b</value>
-					</item>
-					<item>
-						<value>c</value>
-					</item>
-					<item>
 						<value>w</value>
 					</item>
 					<item>
@@ -286,6 +277,15 @@
 					</item>
 					<item>
 						<value>z</value>
+					</item>
+					<item>
+						<value>a</value>
+					</item>
+					<item>
+						<value>b</value>
+					</item>
+					<item>
+						<value>c</value>
 					</item>
 				</list>
 			</expected>
@@ -294,15 +294,6 @@
 			<expected>
 				<list>
 					<item>
-						<value>a</value>
-					</item>
-					<item>
-						<value>b</value>
-					</item>
-					<item>
-						<value>c</value>
-					</item>
-					<item>
 						<value>w</value>
 					</item>
 					<item>
@@ -313,6 +304,15 @@
 					</item>
 					<item>
 						<value>z</value>
+					</item>
+					<item>
+						<value>a</value>
+					</item>
+					<item>
+						<value>b</value>
+					</item>
+					<item>
+						<value>c</value>
 					</item>
 				</list>
 			</expected>

--- a/TestCases/compliance-level-3/0009-append-flatten/0009-append-flatten.dmn
+++ b/TestCases/compliance-level-3/0009-append-flatten/0009-append-flatten.dmn
@@ -45,7 +45,7 @@
 			<requiredInput href="#_4e72e88f-2239-43b8-9944-4893daf84127"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>append(simpleList,nestedList)</text>
+			<text>append(nestedList,simpleList)</text>
 		</literalExpression>
 	</decision>
 	<decision id="_877fd216-703c-4b2f-8197-9f3ed144ff4d" name="append3">
@@ -57,7 +57,7 @@
 			<requiredInput href="#_4e72e88f-2239-43b8-9944-4893daf84127"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>append(literalSimpleList,nestedList)</text>
+			<text>append(nestedList,literalSimpleList)</text>
 		</literalExpression>
 	</decision>
 	<decision id="_cf4db6c6-da6b-42fe-8f85-110f8d711111" name="append4">
@@ -69,7 +69,7 @@
 			<requiredDecision href="#_d6152254-7ad2-4aeb-90a0-16b962a11257"/>
 		</informationRequirement>
 		<literalExpression>
-			<text>append(literalSimpleList,literalNestedList)</text>
+			<text>append(literalNestedList,literalSimpleList)</text>
 		</literalExpression>
 	</decision>
 	<decision id="_84459bf0-7e3a-4897-8f0d-5abb51b1d564" name="flatten1">


### PR DESCRIPTION
Currently the following node/decision:
`append2`
`append3`
`append4`

do evaluate to `[a, b, c, [[w, x], y, z]]`

This is not compatible with declared type `tNestedList`, being the
actual value above a list-of-tNestedList.

In order to make the test compatible with the declared type, it is 
proposed to change the expression in order to make them evaluate to
`[[w, x], y, z, [a, b, c]]`
which is compatible with the current declared type `tNestedList`.

In other words, instead of appending a `tNestedList` inside a
`tStringList`, and inadvertently create a 3 level deep list, change
affected expressions to appending a `tStringList` inside a `tNestedList`.
This is because `tNestedList` elements are indeed expected to be of type
`tStringList`.